### PR TITLE
chore: rename github URLs tommyroar → robogeosociety

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: Claude PR Assistant
 
-# Canonical @claude responder — source of truth: tommyroar/.github.
+# Canonical @claude responder — source of truth: robogeosociety/.github.
 # Synced into every owned repo by scripts/sync.sh. Also selectable one-click
 # from the Actions "New workflow" UI. Auth: CLAUDE_CODE_OAUTH_TOKEN (Max sub).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,5 +4,5 @@ PR descriptions follow the **newspaper / information-pyramid** format: one self-
 front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
 verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
 up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
-Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
-the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).
+Full rules: <https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `robogeosociety/pr-newspaper`).

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A reusable Vite + React + TypeScript engine for Mapbox-driven scrollytelling sites. Drop a `content/` directory of YAML + markdown into a fork of this repo and you get a deployable static site with cinematic camera flights, layer toggles, route tracers, and photo sliders.
 
 The engine extracts the shared shell from projects like
-[JudkinsParkForPeople](https://github.com/tommyroar/JudkinsParkForPeople) and
-[sporty40](https://github.com/tommyroar/sporty40).
+[JudkinsParkForPeople](https://github.com/robogeosociety/JudkinsParkForPeople) and
+[sporty40](https://github.com/robogeosociety/sporty40).
 
 ## Quick start
 

--- a/content/about.md
+++ b/content/about.md
@@ -1,4 +1,4 @@
 # Sporty 40
 
-A trip narrative ported from [tommyroar/sporty40](https://github.com/tommyroar/sporty40)
+A trip narrative ported from [robogeosociety/sporty40](https://github.com/robogeosociety/sporty40)
 into the reusable Mapbox scrollytelling generator.


### PR DESCRIPTION
`fleet` — **ORG RENAME**

Mechanical URL sweep after the tommyroar → robogeosociety org migration — README sibling-project links (JudkinsParkForPeople, sporty40), the ported-from link in `content/about.md`, AGENTS.md PR-framework links, and the `claude.yml` source-of-truth comment. Old github.com URLs redirect, so this is canonical cleanup, not a fix; no Pages project URLs are referenced in this repo.

## Verification
- `grep -rn tommyroar` — remaining hits: 1, a protected form (`LICENSE:3` copyright line — a person's username, not a repo owner URL)
- CI checks expected: none on PRs (deploy.yml runs on push to main only); Pages deploy re-runs on merge

## Risk & rollout
- Doc/URL-only (no logic change); redirects cover the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
